### PR TITLE
Create web app for Swiss Chess League workbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# Swiss Chess League Manager
+
+This repository now ships a browser-based recreation of the original `SwissChessLeaguev4.xlsm` workbook. It keeps the same player roster, Round 1 pairings, and tournament rules while adding a modern interface for entering results and generating additional Swiss rounds.
+
+## Getting started
+
+1. Start a local static file server from the repository root. For example, with Python installed you can run:
+   ```bash
+   python -m http.server 8000
+   ```
+2. Open your browser at [http://localhost:8000](http://localhost:8000) and load `index.html`.
+
+No build tooling or external dependencies are required – everything runs directly in the browser.
+
+## Features
+
+- ✅ Rules panel reproducing the explanatory text from the `Rules` worksheet.
+- ✅ Player directory containing the full contact list from the `Matches` worksheet.
+- ✅ Standings table with live win/draw/loss tallies, manual score adjustments, and opponent history.
+- ✅ Interactive match cards for every recorded round (Round 1 pre-loaded from the workbook).
+- ✅ One-click generation of future rounds using a Swiss pairing algorithm that respects the “no rematches” constraint and uses the workbook’s random seeds as tie-breakers.
+
+## Notes
+
+- Results are stored in-memory. Refreshing the page resets the state to match the Excel workbook.
+- When generating additional rounds, ensure all matches in the current schedule have recorded results.
+- If an odd number of players ever needs to be paired, the UI will automatically assign a bye worth 1 point.
+
+Enjoy running your Swiss tournaments on the web! 🏆

--- a/index.html
+++ b/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Swiss Chess League Manager</title>
+    <link rel="stylesheet" href="src/styles.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <h1>Swiss Chess League Manager</h1>
+      <p class="tagline">Web recreation of the SwissChessLeaguev4.xlsm workbook</p>
+    </header>
+    <main id="app"></main>
+    <script type="module" src="src/app.js"></script>
+  </body>
+</html>

--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,524 @@
+import { rulesText, players as playerSeedData, initialPairings } from './data.js';
+
+const RESULT = {
+  UNPLAYED: 'UNPLAYED',
+  PLAYER1: 'PLAYER1',
+  PLAYER2: 'PLAYER2',
+  DRAW: 'DRAW',
+  BYE: 'BYE'
+};
+
+const state = createInitialState();
+
+function createInitialState() {
+  const players = playerSeedData.map((player) => ({
+    ...player,
+    addScore: 0,
+    history: []
+  }));
+
+  const rounds = [
+    {
+      roundNumber: 1,
+      pairings: initialPairings.map((pairing) => ({
+        ...pairing,
+        result: RESULT.UNPLAYED
+      }))
+    }
+  ];
+
+  return { players, rounds };
+}
+
+function resetTournament() {
+  const fresh = createInitialState();
+  state.players = fresh.players;
+  state.rounds = fresh.rounds;
+  renderApp();
+}
+
+function createElement(tag, options = {}, ...children) {
+  const el = document.createElement(tag);
+  if (options.className) {
+    el.className = options.className;
+  }
+  if (options.dataset) {
+    Object.entries(options.dataset).forEach(([key, value]) => {
+      el.dataset[key] = value;
+    });
+  }
+  if (options.attrs) {
+    Object.entries(options.attrs).forEach(([key, value]) => {
+      if (value === undefined || value === null) return;
+      el.setAttribute(key, value);
+    });
+  }
+  if (options.textContent !== undefined) {
+    el.textContent = options.textContent;
+  }
+  children.flat().forEach((child) => {
+    if (child === null || child === undefined) return;
+    el.appendChild(typeof child === 'string' ? document.createTextNode(child) : child);
+  });
+  return el;
+}
+
+function getPlayerById(id) {
+  return state.players.find((player) => player.id === id);
+}
+
+function gatherOpponentHistory() {
+  const history = new Map();
+  state.players.forEach((player) => {
+    history.set(player.id, new Set());
+  });
+
+  state.rounds.forEach((round) => {
+    round.pairings.forEach((pairing) => {
+      if (!pairing.player1 || !pairing.player2) return;
+      history.get(pairing.player1).add(pairing.player2);
+      history.get(pairing.player2).add(pairing.player1);
+    });
+  });
+
+  return history;
+}
+
+function recalculateStandings() {
+  const statsMap = new Map();
+
+  state.players.forEach((player) => {
+    statsMap.set(player.id, {
+      id: player.id,
+      seed: player.seed,
+      name: player.fullName || player.name,
+      displayName: player.name,
+      addScore: player.addScore ?? 0,
+      opponents: new Set(),
+      wins: 0,
+      losses: 0,
+      draws: 0,
+      byes: 0,
+      basePoints: 0
+    });
+  });
+
+  state.rounds.forEach((round) => {
+    round.pairings.forEach((pairing) => {
+      const { player1, player2, result } = pairing;
+      const p1Stats = statsMap.get(player1);
+      const p2Stats = player2 ? statsMap.get(player2) : null;
+
+      if (player2) {
+        p1Stats.opponents.add(player2);
+        if (p2Stats) {
+          p2Stats.opponents.add(player1);
+        }
+      }
+
+      switch (result) {
+        case RESULT.PLAYER1:
+          p1Stats.wins += 1;
+          p1Stats.basePoints += 1;
+          if (p2Stats) {
+            p2Stats.losses += 1;
+          }
+          break;
+        case RESULT.PLAYER2:
+          if (p2Stats) {
+            p2Stats.wins += 1;
+            p2Stats.basePoints += 1;
+          }
+          p1Stats.losses += 1;
+          break;
+        case RESULT.DRAW:
+          p1Stats.draws += 1;
+          p1Stats.basePoints += 0.5;
+          if (p2Stats) {
+            p2Stats.draws += 1;
+            p2Stats.basePoints += 0.5;
+          }
+          break;
+        case RESULT.BYE:
+          p1Stats.byes += 1;
+          p1Stats.basePoints += 1;
+          p1Stats.opponents.add('Bye');
+          break;
+        default:
+          break;
+      }
+    });
+  });
+
+  const standings = Array.from(statsMap.values()).map((stats) => {
+    const gamesPlayed = stats.wins + stats.losses + stats.draws + stats.byes;
+    const totalPoints = stats.basePoints + stats.addScore;
+    const winPercent = gamesPlayed === 0 ? 0 : (stats.basePoints / gamesPlayed) * 100;
+    const opponentSummaries = Array.from(stats.opponents).map((opponent) => {
+      if (opponent === 'Bye') {
+        return 'Bye';
+      }
+      const opponentData = getPlayerById(opponent);
+      return opponentData ? `${opponentData.name} (#${opponentData.id})` : `#${opponent}`;
+    });
+
+    return {
+      ...stats,
+      gamesPlayed,
+      totalPoints,
+      winPercent,
+      opponentSummaries
+    };
+  });
+
+  standings.sort((a, b) => {
+    if (b.totalPoints !== a.totalPoints) {
+      return b.totalPoints - a.totalPoints;
+    }
+    if (b.basePoints !== a.basePoints) {
+      return b.basePoints - a.basePoints;
+    }
+    if (b.winPercent !== a.winPercent) {
+      return b.winPercent - a.winPercent;
+    }
+    return a.seed - b.seed;
+  });
+
+  return standings;
+}
+
+function handleAddScoreChange(playerId, value) {
+  const player = getPlayerById(playerId);
+  if (!player) return;
+  const numericValue = Number.parseFloat(value);
+  player.addScore = Number.isFinite(numericValue) ? numericValue : 0;
+  renderApp();
+}
+
+function setMatchResult(roundIndex, table, result) {
+  const round = state.rounds[roundIndex];
+  if (!round) return;
+  const pairing = round.pairings.find((match) => match.table === table);
+  if (!pairing) return;
+
+  pairing.result = result;
+  renderApp();
+}
+
+function canGenerateNextRound() {
+  return state.rounds.every((round) => round.pairings.every((pairing) => pairing.result !== RESULT.UNPLAYED));
+}
+
+function generateNextRound() {
+  if (!canGenerateNextRound()) {
+    alert('Please enter results for every match before pairing the next round.');
+    return;
+  }
+
+  const standings = recalculateStandings();
+  const opponentHistory = gatherOpponentHistory();
+  const playersToPair = standings.map((entry) => entry.id);
+  const pairings = createSwissPairings(playersToPair, opponentHistory);
+  const nextRoundNumber = state.rounds.length + 1;
+
+  state.rounds.push({
+    roundNumber: nextRoundNumber,
+    pairings: pairings.map((pair, index) => {
+      if (pair.length === 1) {
+        return {
+          table: index + 1,
+          player1: pair[0],
+          player2: null,
+          player1Name: getPlayerById(pair[0]).name,
+          player2Name: 'Bye',
+          result: RESULT.BYE
+        };
+      }
+
+      const [player1Id, player2Id] = pair;
+      return {
+        table: index + 1,
+        player1: player1Id,
+        player2: player2Id,
+        player1Name: getPlayerById(player1Id).name,
+        player2Name: getPlayerById(player2Id).name,
+        result: RESULT.UNPLAYED
+      };
+    })
+  });
+
+  renderApp();
+}
+
+function createSwissPairings(playerIds, opponentHistory) {
+  const pool = [...playerIds];
+  let byePlayer = null;
+
+  if (pool.length % 2 === 1) {
+    byePlayer = pool.pop();
+  }
+
+  let solution = null;
+
+  function backtrack(available, currentPairs) {
+    if (available.length === 0) {
+      solution = currentPairs;
+      return true;
+    }
+
+    const [player, ...rest] = available;
+
+    for (let i = 0; i < rest.length; i += 1) {
+      const opponent = rest[i];
+      if (opponentHistory.get(player).has(opponent)) {
+        continue;
+      }
+      const remaining = rest.slice(0, i).concat(rest.slice(i + 1));
+      if (backtrack(remaining, [...currentPairs, [player, opponent]])) {
+        return true;
+      }
+    }
+
+    for (let i = 0; i < rest.length; i += 1) {
+      const opponent = rest[i];
+      const remaining = rest.slice(0, i).concat(rest.slice(i + 1));
+      if (backtrack(remaining, [...currentPairs, [player, opponent]])) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  if (!backtrack(pool, [])) {
+    throw new Error('Unable to create Swiss pairings without conflicts.');
+  }
+
+  const finalPairs = solution ? [...solution] : [];
+  if (byePlayer !== null) {
+    finalPairs.push([byePlayer]);
+  }
+  return finalPairs;
+}
+
+function renderRulesPanel() {
+  const panel = createElement('section', { className: 'panel' });
+  const title = createElement('h2', {}, createElement('span', { className: 'emoji' }, '📘'), 'Rules overview');
+  const description = createElement('div', { className: 'rules-list' });
+
+  description.append(
+    ...rulesText.map((paragraph) => {
+      if (paragraph === 'Swiss-style tournaments were developed to counteract this problem. Swiss-style tournaments generally have two rules:') {
+        const intro = createElement('p', { textContent: paragraph });
+        const list = createElement('ul');
+        list.append(
+          createElement('li', { textContent: 'Participants are paired with opponents who have similar scores.' }),
+          createElement('li', { textContent: 'Participants cannot play the same opponent twice.' })
+        );
+        return createElement('div', {}, intro, list);
+      }
+      return createElement('p', { textContent: paragraph });
+    })
+  );
+
+  panel.append(title, description);
+  return panel;
+}
+
+function renderStandingsPanel() {
+  const panel = createElement('section', { className: 'panel' });
+  const header = createElement('div', { className: 'controls' });
+  const title = createElement('h2', {}, createElement('span', { className: 'emoji' }, '🏆'), 'Tournament control centre');
+  header.append(title);
+
+  const controls = createElement('div', { className: 'controls' });
+  const nextRoundButton = createElement('button', {
+    className: 'primary',
+    textContent: 'Generate next round',
+    attrs: { type: 'button' }
+  });
+  nextRoundButton.disabled = !canGenerateNextRound();
+  nextRoundButton.addEventListener('click', generateNextRound);
+
+  const resetButton = createElement('button', {
+    className: 'secondary',
+    textContent: 'Reset tournament',
+    attrs: { type: 'button' }
+  });
+  resetButton.addEventListener('click', resetTournament);
+
+  controls.append(nextRoundButton, resetButton);
+
+  const standings = recalculateStandings();
+
+  const table = createElement('table');
+  const thead = createElement('thead');
+  const headerRow = createElement('tr');
+  ['Rank', 'Player', 'Score', 'Adjust', 'Total', 'Win %', 'Opponents'].forEach((label) => {
+    headerRow.append(createElement('th', { textContent: label }));
+  });
+  thead.append(headerRow);
+
+  const tbody = createElement('tbody');
+  standings.forEach((entry, index) => {
+    const row = createElement('tr');
+    row.append(createElement('td', { textContent: `#${index + 1}` }));
+    row.append(
+      createElement('td', {},
+        createElement('div', { className: 'meta-grid' },
+          createElement('strong', { textContent: `${entry.displayName} (ID ${entry.id})` }),
+          createElement('span', { textContent: `Seed: ${entry.seed}` })
+        )
+      )
+    );
+    row.append(createElement('td', { textContent: entry.basePoints.toFixed(1) }));
+
+    const input = createElement('input', {
+      attrs: { type: 'number', step: '0.5', value: entry.addScore }
+    });
+    input.addEventListener('change', (event) => {
+      handleAddScoreChange(entry.id, event.target.value);
+    });
+    row.append(createElement('td', {}, input));
+
+    row.append(createElement('td', { textContent: entry.totalPoints.toFixed(1) }));
+    row.append(createElement('td', { textContent: `${entry.winPercent.toFixed(1)}%` }));
+
+    if (!entry.opponentSummaries.length) {
+      row.append(createElement('td', { textContent: '—' }));
+    } else {
+      row.append(createElement('td', { textContent: entry.opponentSummaries.join(', ') }));
+    }
+
+    tbody.append(row);
+  });
+
+  table.append(thead, tbody);
+
+  panel.append(header, controls, createElement('div', { className: 'table-wrapper' }, table), renderRoundsSection());
+  return panel;
+}
+
+function renderRoundsSection() {
+  const container = createElement('div', {});
+
+  state.rounds.forEach((round, roundIndex) => {
+    const completed = round.pairings.every((pairing) => pairing.result !== RESULT.UNPLAYED);
+    const roundCard = createElement('div', { className: 'round-card' });
+    const roundHeader = createElement('div', { className: 'round-header' });
+    const title = createElement('h3', { textContent: `Round ${round.roundNumber}` });
+    const status = createElement('span', {
+      className: 'badge ' + (completed ? 'win' : ''),
+      textContent: completed ? 'Completed' : 'Awaiting results'
+    });
+
+    roundHeader.append(title, status);
+    roundCard.append(roundHeader);
+
+    if (round.pairings.length === 0) {
+      roundCard.append(createElement('div', { className: 'empty-state', textContent: 'No matches scheduled yet.' }));
+    } else {
+      round.pairings.forEach((pairing) => {
+        roundCard.append(renderMatchRow(roundIndex, pairing));
+      });
+    }
+
+    container.append(roundCard);
+  });
+
+  return container;
+}
+
+function renderMatchRow(roundIndex, pairing) {
+  const { table, player1, player2, player1Name, player2Name, result } = pairing;
+  const row = createElement('div', { className: 'match-row' });
+
+  row.append(createElement('div', { className: 'table-id badge', textContent: `Table ${table}` }));
+
+  const player1Info = getPlayerById(player1);
+  const player2Info = player2 ? getPlayerById(player2) : null;
+
+  const player1Block = createElement('div', { className: 'player' },
+    createElement('span', { textContent: `${player1Name || (player1Info?.name ?? 'Player')} (#${player1})` }),
+    createElement('span', { textContent: player1Info ? player1Info.department || '—' : '—' })
+  );
+
+  const player2Block = createElement('div', { className: 'player' },
+    createElement('span', { textContent: player2 ? `${player2Name || (player2Info?.name ?? 'Player')} (#${player2})` : 'Bye' }),
+    createElement('span', { textContent: player2Info ? player2Info.department || '—' : '—' })
+  );
+
+  const versus = createElement('div', { className: 'versus', textContent: 'vs' });
+
+  const select = createElement('select', {
+    className: 'match-result',
+    attrs: { 'aria-label': `Result for table ${table}` }
+  });
+  [
+    { value: RESULT.UNPLAYED, label: 'Not played' },
+    { value: RESULT.PLAYER1, label: `${player1Name || 'Player 1'} wins` },
+    { value: RESULT.DRAW, label: 'Draw' },
+    { value: RESULT.PLAYER2, label: `${player2Name || 'Player 2'} wins` }
+  ].forEach((option) => {
+    if (!player2 && option.value === RESULT.PLAYER2) return;
+    const optionEl = createElement('option', {
+      attrs: { value: option.value },
+      textContent: option.label
+    });
+    if (option.value === result) {
+      optionEl.selected = true;
+    }
+    select.append(optionEl);
+  });
+
+  if (!player2) {
+    select.disabled = true;
+  }
+
+  select.addEventListener('change', (event) => {
+    setMatchResult(roundIndex, table, event.target.value);
+  });
+
+  row.append(player1Block, versus, player2Block, select);
+  return row;
+}
+
+function renderDirectoryPanel() {
+  const panel = createElement('section', { className: 'panel' });
+  const title = createElement('h2', {}, createElement('span', { className: 'emoji' }, '📇'), 'Player directory');
+  const wrapper = createElement('div', { className: 'table-wrapper' });
+  const table = createElement('table');
+  const headRow = createElement('tr');
+  ['ID', 'Name', 'Contact', 'Department', 'Register no.'].forEach((label) => {
+    headRow.append(createElement('th', { textContent: label }));
+  });
+  const thead = createElement('thead', {}, headRow);
+  const tbody = createElement('tbody');
+
+  [...state.players]
+    .sort((a, b) => a.id - b.id)
+    .forEach((player) => {
+      const row = createElement('tr');
+      row.append(
+        createElement('td', { textContent: `#${player.id}` }),
+        createElement('td', { textContent: player.name }),
+        createElement('td', { textContent: player.contact || '—' }),
+        createElement('td', { textContent: player.department || '—' }),
+        createElement('td', { textContent: player.registerNumber || '—' })
+      );
+      tbody.append(row);
+    });
+
+  table.append(thead, tbody);
+  wrapper.append(table);
+  panel.append(title, wrapper);
+  return panel;
+}
+
+function renderApp() {
+  const root = document.getElementById('app');
+  root.innerHTML = '';
+  root.append(renderRulesPanel(), renderStandingsPanel(), renderDirectoryPanel());
+}
+
+renderApp();

--- a/src/data.js
+++ b/src/data.js
@@ -1,0 +1,641 @@
+export const rulesText = [
+  "What is a Swiss-style Tournament?",
+  "Right, so what are we trying to do anyway? We’re trying to code a Tournament Manager, which is useful for things like e-sports, trading card games, and anything else that’s vaguely competitive. In general, tournaments aim to determine the best player/team (I’ll just use player from now on) in a competition; obviously, the best way to go about this is to make each participant play each other, and the player with the highest score at the end of it all wins — this is known as a “Round-Robin” style tournament.",
+  "The problem with a Round-Robin tournament is that it doesn’t scale very well to large numbers of participants. For example, 4-player round-robin tournament requires 3 rounds to be played. But the same tournament style for 32 players would require 31 rounds — a logistical nightmare at beast.",
+  "Swiss-style tournaments were developed to counteract this problem. Swiss-style tournaments generally have two rules:",
+  "Participants are paired with opponents who have similar scores.",
+  "Participants cannot play the same opponent twice.",
+  "In this way, the tournament aims to pair similarly ranked players until a winner is determined, and this process generally takes much fewer rounds than a round-robin tournament to resolve. For example, a 32-player Swiss tournament would only need 5 rounds to conclude rather than a 31-Round-Robin tournament — much better!",
+  "Thus, to create our Tournament Manager app, we’re first going to need to come with an algorithm that does the above."
+];
+
+export const players = [
+  {
+    "id": 1,
+    "name": "aditya dhyani",
+    "fullName": "Aditya Dhyani",
+    "contact": "9557648750",
+    "department": "bcs csds",
+    "registerNumber": "25112001",
+    "seed": 94
+  },
+  {
+    "id": 2,
+    "name": "Ananth Krishna NB",
+    "fullName": "Ananth Krishna Nb",
+    "contact": "9448780711",
+    "department": "1 BBA LLB",
+    "registerNumber": "",
+    "seed": 33
+  },
+  {
+    "id": 3,
+    "name": "saurya thakkar",
+    "fullName": "Saurya Thakkar",
+    "contact": "9724297440",
+    "department": "1 BscCSDS PLC",
+    "registerNumber": "",
+    "seed": 10
+  },
+  {
+    "id": 4,
+    "name": "Thakkar harmik",
+    "fullName": "Thakkar Harmik",
+    "contact": "8200226290",
+    "department": "1MSCDS",
+    "registerNumber": "",
+    "seed": 76
+  },
+  {
+    "id": 5,
+    "name": "Santhoshkrishna GM",
+    "fullName": "Santhoshkrishna Gm",
+    "contact": "9585851325",
+    "department": "5BBA.LLB",
+    "registerNumber": "23113158",
+    "seed": 50
+  },
+  {
+    "id": 6,
+    "name": "kaif khan",
+    "fullName": "Kaif Khan",
+    "contact": "8542066736",
+    "department": "1BBA BA",
+    "registerNumber": "",
+    "seed": 29
+  },
+  {
+    "id": 7,
+    "name": "HIMANSHU RAJ",
+    "fullName": "Himanshu Raj",
+    "contact": "9509444178",
+    "department": "BBA BA",
+    "registerNumber": "25111216",
+    "seed": 63
+  },
+  {
+    "id": 8,
+    "name": "Swastik Pandey",
+    "fullName": "Swastik Pandey",
+    "contact": "9369555028",
+    "department": "1 BSC ES",
+    "registerNumber": "",
+    "seed": 97
+  },
+  {
+    "id": 9,
+    "name": "Alen Join Shibu",
+    "fullName": "Alen Join Shibu",
+    "contact": "8590542504",
+    "department": "5BSc.DS",
+    "registerNumber": "",
+    "seed": 70
+  },
+  {
+    "id": 10,
+    "name": "Aviroop Sinha",
+    "fullName": "Aviroop Sinha",
+    "contact": "9330829658",
+    "department": "3BCom Fa",
+    "registerNumber": "",
+    "seed": 52
+  },
+  {
+    "id": 11,
+    "name": "Anjali Shitole",
+    "fullName": "Anjali Shitole",
+    "contact": "8369694689",
+    "department": "1st year BCA",
+    "registerNumber": "",
+    "seed": 34
+  },
+  {
+    "id": 12,
+    "name": "Lingeswer.S",
+    "fullName": "Lingeswer.S",
+    "contact": "8072293969",
+    "department": "1Bba Llb",
+    "registerNumber": "",
+    "seed": 90
+  },
+  {
+    "id": 13,
+    "name": "Ansh Kalra",
+    "fullName": "Ansh Kalra",
+    "contact": "6375855016",
+    "department": "3 BBA BA A",
+    "registerNumber": "24111105",
+    "seed": 88
+  },
+  {
+    "id": 14,
+    "name": "Dhepeshnarayana.s",
+    "fullName": "Dhepeshnarayana.S",
+    "contact": "7358787286",
+    "department": "1ba llb",
+    "registerNumber": "",
+    "seed": 11
+  },
+  {
+    "id": 15,
+    "name": "Harshvardhan Singh Rathore",
+    "fullName": "Harshvardhan Singh Rathore",
+    "contact": "7426885333",
+    "department": "MBA",
+    "registerNumber": "",
+    "seed": 80
+  },
+  {
+    "id": 16,
+    "name": "Hans M Abraham",
+    "fullName": "Hans M Abraham",
+    "contact": "7902354121",
+    "department": "1MBA",
+    "registerNumber": "25121017",
+    "seed": 41
+  },
+  {
+    "id": 17,
+    "name": "Akshay K S",
+    "fullName": "Akshay K S",
+    "contact": "8269780209",
+    "department": "3ba llb",
+    "registerNumber": "",
+    "seed": 86
+  },
+  {
+    "id": 18,
+    "name": "Rishit Mishra",
+    "fullName": "Rishit Mishra",
+    "contact": "6307878572",
+    "department": "1BBA BA C",
+    "registerNumber": "",
+    "seed": 87
+  },
+  {
+    "id": 19,
+    "name": "Akshat Chauhan",
+    "fullName": "Akshat Chauhan",
+    "contact": "8004100091",
+    "department": "1 BA LLB PLC",
+    "registerNumber": "25113007",
+    "seed": 24
+  },
+  {
+    "id": 20,
+    "name": "Varghese Anto",
+    "fullName": "Varghese Anto",
+    "contact": "8907086495",
+    "department": "9BBA LLB",
+    "registerNumber": "21113185",
+    "seed": 20
+  },
+  {
+    "id": 21,
+    "name": "Jatin",
+    "fullName": "Jatin",
+    "contact": "8005542110",
+    "department": "5Bba b",
+    "registerNumber": "23111432",
+    "seed": 67
+  },
+  {
+    "id": 22,
+    "name": "Aryan Mhaskar",
+    "fullName": "Aryan Mhaskar",
+    "contact": "9335496172",
+    "department": "7BALLB",
+    "registerNumber": "22113013",
+    "seed": 51
+  },
+  {
+    "id": 23,
+    "name": "Utsav Sahare",
+    "fullName": "Utsav Sahare",
+    "contact": "7558261659",
+    "department": "BBA BA",
+    "registerNumber": "",
+    "seed": 58
+  },
+  {
+    "id": 24,
+    "name": "Kunal",
+    "fullName": "Kunal",
+    "contact": "9560275329",
+    "department": "5 BBA D",
+    "registerNumber": "",
+    "seed": 4
+  },
+  {
+    "id": 25,
+    "name": "Tuba Ahmed",
+    "fullName": "Tuba Ahmed",
+    "contact": "9625974785",
+    "department": "1bse es",
+    "registerNumber": "",
+    "seed": 85
+  },
+  {
+    "id": 26,
+    "name": "Adrika gosh",
+    "fullName": "Adrika Gosh",
+    "contact": "7003446716",
+    "department": "1MSCDS",
+    "registerNumber": "",
+    "seed": 6
+  },
+  {
+    "id": 27,
+    "name": "Aditi Sai",
+    "fullName": "Aditi Sai",
+    "contact": "8109228681",
+    "department": "Bcom",
+    "registerNumber": "",
+    "seed": 58
+  },
+  {
+    "id": 28,
+    "name": "Jai Sinnh Bhargava",
+    "fullName": "Jai Sinnh Bhargava",
+    "contact": "9971449460",
+    "department": "1 Bcom A",
+    "registerNumber": "",
+    "seed": 44
+  },
+  {
+    "id": 29,
+    "name": "Priyanshu Mehra",
+    "fullName": "Priyanshu Mehra",
+    "contact": "9560930597",
+    "department": "1 bba ba",
+    "registerNumber": "25113154",
+    "seed": 55
+  },
+  {
+    "id": 30,
+    "name": "Sparsh Ahuja",
+    "fullName": "Sparsh Ahuja",
+    "contact": "9958472477",
+    "department": "9 Ba Llb",
+    "registerNumber": "21113078",
+    "seed": 78
+  },
+  {
+    "id": 31,
+    "name": "Sherick Matthew",
+    "fullName": "Sherick Matthew",
+    "contact": "8098309889",
+    "department": "9BBAllb",
+    "registerNumber": "",
+    "seed": 4
+  },
+  {
+    "id": 32,
+    "name": "Karasala Abishai",
+    "fullName": "Karasala Abishai",
+    "contact": "9989959685",
+    "department": "5BBA C",
+    "registerNumber": "23111523",
+    "seed": 86
+  },
+  {
+    "id": 33,
+    "name": "Devkrishna",
+    "fullName": "Devkrishna",
+    "contact": "8590286754",
+    "department": "5BSCDS",
+    "registerNumber": "",
+    "seed": 45
+  },
+  {
+    "id": 34,
+    "name": "Sahil kadu",
+    "fullName": "Sahil Kadu",
+    "contact": "7737824141",
+    "department": "3BCA",
+    "registerNumber": "",
+    "seed": 27
+  },
+  {
+    "id": 35,
+    "name": "Divyansh",
+    "fullName": "Divyansh",
+    "contact": "9319828001",
+    "department": "1 BSC ES",
+    "registerNumber": "",
+    "seed": 40
+  },
+  {
+    "id": 36,
+    "name": "Siddharth",
+    "fullName": "Siddharth",
+    "contact": "9789486803",
+    "department": "9BBALLB",
+    "registerNumber": "21113177",
+    "seed": 55
+  },
+  {
+    "id": 37,
+    "name": "prince",
+    "fullName": "Prince",
+    "contact": "7039314403",
+    "department": "3Ballb",
+    "registerNumber": "",
+    "seed": 32
+  },
+  {
+    "id": 38,
+    "name": "Arunabha Dey",
+    "fullName": "Arunabha Dey",
+    "contact": "8336089666",
+    "department": "",
+    "registerNumber": "",
+    "seed": 68
+  },
+  {
+    "id": 39,
+    "name": "Anwesh Chatterjee",
+    "fullName": "Anwesh Chatterjee",
+    "contact": "6289121218",
+    "department": "3BBA A",
+    "registerNumber": "",
+    "seed": 12
+  },
+  {
+    "id": 40,
+    "name": "Devagya Singla",
+    "fullName": "Devagya Singla",
+    "contact": "6283999788",
+    "department": "1 BBA BA",
+    "registerNumber": "",
+    "seed": 94
+  },
+  {
+    "id": 41,
+    "name": "Abhinay Sahu",
+    "fullName": "Abhinay Sahu",
+    "contact": "7722867533",
+    "department": "",
+    "registerNumber": "",
+    "seed": 82
+  },
+  {
+    "id": 42,
+    "name": "Rushiraj Patel",
+    "fullName": "Rushiraj Patel",
+    "contact": "9773265329",
+    "department": "1BBA HONS",
+    "registerNumber": "25111533",
+    "seed": 84
+  },
+  {
+    "id": 43,
+    "name": "Jovian Anderson Chyne",
+    "fullName": "Jovian Anderson Chyne",
+    "contact": "9226464409",
+    "department": "BSC. ES",
+    "registerNumber": "25112306",
+    "seed": 26
+  },
+  {
+    "id": 44,
+    "name": "arshad PR",
+    "fullName": "Arshad Pr",
+    "contact": "9526066338",
+    "department": "9BA LLB",
+    "registerNumber": "21113011",
+    "seed": 61
+  },
+  {
+    "id": 45,
+    "name": "Buddha Hari Haran",
+    "fullName": "Buddha Hari Haran",
+    "contact": "9390220625",
+    "department": "5BBA B",
+    "registerNumber": "23111423",
+    "seed": 41
+  },
+  {
+    "id": 46,
+    "name": "Vishal Yadav",
+    "fullName": "Vishal Yadav",
+    "contact": "9588501055",
+    "department": "1BCA",
+    "registerNumber": "",
+    "seed": 14
+  },
+  {
+    "id": 47,
+    "name": "Yogyata Singh",
+    "fullName": "Yogyata Singh",
+    "contact": "8789739266",
+    "department": "1BSCCSDS",
+    "registerNumber": "",
+    "seed": 74
+  },
+  {
+    "id": 48,
+    "name": "Vashitav Bali",
+    "fullName": "Vashitav Bali",
+    "contact": "9541355388",
+    "department": "1bcom",
+    "registerNumber": "25114045",
+    "seed": 21
+  },
+  {
+    "id": 49,
+    "name": "Devesh Tiwari",
+    "fullName": "Devesh Tiwari",
+    "contact": "8400616871",
+    "department": "5BBA",
+    "registerNumber": "23113120",
+    "seed": 37
+  },
+  {
+    "id": 50,
+    "name": "Harshith Shresth",
+    "fullName": "Harshith Shresth",
+    "contact": "",
+    "department": "BBA BA",
+    "registerNumber": "25111249",
+    "seed": 55
+  }
+];
+
+export const initialPairings = [
+  {
+    "table": 1,
+    "player1": 43,
+    "player2": 8,
+    "player1Name": "Jovian Anderson Chyne",
+    "player2Name": "Swastik Pandey"
+  },
+  {
+    "table": 2,
+    "player1": 37,
+    "player2": 50,
+    "player1Name": "Prince",
+    "player2Name": "Harshith Shresth"
+  },
+  {
+    "table": 3,
+    "player1": 16,
+    "player2": 10,
+    "player1Name": "Hans M Abraham",
+    "player2Name": "Aviroop Sinha"
+  },
+  {
+    "table": 4,
+    "player1": 9,
+    "player2": 44,
+    "player1Name": "Alen Join Shibu",
+    "player2Name": "Arshad Pr"
+  },
+  {
+    "table": 5,
+    "player1": 6,
+    "player2": 22,
+    "player1Name": "Kaif Khan",
+    "player2Name": "Aryan Mhaskar"
+  },
+  {
+    "table": 6,
+    "player1": 7,
+    "player2": 4,
+    "player1Name": "Himanshu Raj",
+    "player2Name": "Thakkar Harmik"
+  },
+  {
+    "table": 7,
+    "player1": 36,
+    "player2": 48,
+    "player1Name": "Siddharth",
+    "player2Name": "Vashitav Bali"
+  },
+  {
+    "table": 8,
+    "player1": 19,
+    "player2": 20,
+    "player1Name": "Akshat Chauhan",
+    "player2Name": "Varghese Anto"
+  },
+  {
+    "table": 9,
+    "player1": 42,
+    "player2": 17,
+    "player1Name": "Rushiraj Patel",
+    "player2Name": "Akshay K S"
+  },
+  {
+    "table": 10,
+    "player1": 3,
+    "player2": 18,
+    "player1Name": "Saurya Thakkar",
+    "player2Name": "Rishit Mishra"
+  },
+  {
+    "table": 11,
+    "player1": 25,
+    "player2": 28,
+    "player1Name": "Tuba Ahmed",
+    "player2Name": "Jai Sinnh Bhargava"
+  },
+  {
+    "table": 12,
+    "player1": 47,
+    "player2": 33,
+    "player1Name": "Yogyata Singh",
+    "player2Name": "Devkrishna"
+  },
+  {
+    "table": 13,
+    "player1": 11,
+    "player2": 45,
+    "player1Name": "Anjali Shitole",
+    "player2Name": "Buddha Hari Haran"
+  },
+  {
+    "table": 14,
+    "player1": 30,
+    "player2": 40,
+    "player1Name": "Sparsh Ahuja",
+    "player2Name": "Devagya Singla"
+  },
+  {
+    "table": 15,
+    "player1": 21,
+    "player2": 31,
+    "player1Name": "Jatin",
+    "player2Name": "Sherick Matthew"
+  },
+  {
+    "table": 16,
+    "player1": 2,
+    "player2": 24,
+    "player1Name": "Ananth Krishna Nb",
+    "player2Name": "Kunal"
+  },
+  {
+    "table": 17,
+    "player1": 38,
+    "player2": 23,
+    "player1Name": "Arunabha Dey",
+    "player2Name": "Utsav Sahare"
+  },
+  {
+    "table": 18,
+    "player1": 32,
+    "player2": 41,
+    "player1Name": "Karasala Abishai",
+    "player2Name": "Abhinay Sahu"
+  },
+  {
+    "table": 19,
+    "player1": 46,
+    "player2": 12,
+    "player1Name": "Vishal Yadav",
+    "player2Name": "Lingeswer.S"
+  },
+  {
+    "table": 20,
+    "player1": 39,
+    "player2": 26,
+    "player1Name": "Anwesh Chatterjee",
+    "player2Name": "Adrika Gosh"
+  },
+  {
+    "table": 21,
+    "player1": 1,
+    "player2": 29,
+    "player1Name": "Aditya Dhyani",
+    "player2Name": "Priyanshu Mehra"
+  },
+  {
+    "table": 22,
+    "player1": 49,
+    "player2": 14,
+    "player1Name": "Devesh Tiwari",
+    "player2Name": "Dhepeshnarayana.S"
+  },
+  {
+    "table": 23,
+    "player1": 15,
+    "player2": 35,
+    "player1Name": "Harshvardhan Singh Rathore",
+    "player2Name": "Divyansh"
+  },
+  {
+    "table": 24,
+    "player1": 5,
+    "player2": 13,
+    "player1Name": "Santhoshkrishna Gm",
+    "player2Name": "Ansh Kalra"
+  },
+  {
+    "table": 25,
+    "player1": 34,
+    "player2": 27,
+    "player1Name": "Sahil Kadu",
+    "player2Name": "Aditi Sai"
+  }
+];

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,319 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.5;
+  font-size: 16px;
+  background-color: #f4f5f8;
+  color: #111827;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, rgba(59, 130, 246, 0.08), transparent 55%),
+    linear-gradient(180deg, rgba(15, 23, 42, 0.04), transparent 220px);
+}
+
+.app-header {
+  padding: 2.5rem clamp(1rem, 4vw, 3.5rem) 1.5rem;
+  text-align: center;
+  background: linear-gradient(135deg, #1e3a8a, #3b82f6);
+  color: #f8fafc;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.25);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.app-header h1 {
+  margin: 0 0 0.35rem;
+  font-size: clamp(1.75rem, 4vw, 2.75rem);
+  letter-spacing: 0.05em;
+}
+
+.app-header .tagline {
+  margin: 0;
+  font-size: clamp(0.95rem, 2vw, 1.1rem);
+  color: rgba(248, 250, 252, 0.85);
+}
+
+main#app {
+  padding: clamp(1.25rem, 3vw, 2.75rem);
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.panel {
+  background: rgba(255, 255, 255, 0.9);
+  backdrop-filter: blur(6px);
+  border-radius: 20px;
+  padding: clamp(1.25rem, 2.5vw, 2rem);
+  box-shadow: 0 15px 35px rgba(15, 23, 42, 0.12);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.panel h2 {
+  margin-top: 0;
+  font-size: clamp(1.25rem, 2.5vw, 1.75rem);
+  color: #1f2937;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.panel h2 .emoji {
+  font-size: 1.4em;
+}
+
+.rules-list {
+  display: grid;
+  gap: 1rem;
+  color: #1f2937;
+}
+
+.rules-list p {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.rules-list ul {
+  margin: 0.25rem 0 0 1.5rem;
+  padding: 0;
+}
+
+.section-title {
+  margin: 0 0 1rem;
+  font-size: 1.1rem;
+  color: #0f172a;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 720px;
+  background: rgba(248, 250, 252, 0.9);
+}
+
+th, td {
+  padding: 0.65rem 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(226, 232, 240, 0.7);
+}
+
+th {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  background: rgba(59, 130, 246, 0.12);
+  color: #0f172a;
+}
+
+tr:last-child td {
+  border-bottom: none;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  border-radius: 999px;
+  padding: 0.2rem 0.7rem;
+  background: rgba(59, 130, 246, 0.12);
+  color: #1d4ed8;
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+button.primary {
+  border: none;
+  border-radius: 999px;
+  padding: 0.6rem 1.4rem;
+  background: linear-gradient(135deg, #2563eb, #3b82f6);
+  color: white;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 10px 25px rgba(37, 99, 235, 0.35);
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+button.primary:disabled {
+  background: linear-gradient(135deg, rgba(148, 163, 184, 0.6), rgba(148, 163, 184, 0.75));
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+button.primary:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 32px rgba(37, 99, 235, 0.45);
+}
+
+button.secondary {
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  background: rgba(255, 255, 255, 0.6);
+  padding: 0.55rem 1.3rem;
+  color: #0f172a;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.18s ease, transform 0.18s ease;
+}
+
+button.secondary:hover {
+  background: rgba(226, 232, 240, 0.8);
+  transform: translateY(-1px);
+}
+
+select.match-result {
+  padding: 0.35rem 0.5rem;
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.5);
+  background: white;
+  font-weight: 500;
+}
+
+input[type="number"] {
+  width: 4rem;
+  padding: 0.35rem 0.5rem;
+  border-radius: 8px;
+  border: 1px solid rgba(148, 163, 184, 0.6);
+  background: rgba(255, 255, 255, 0.85);
+  font-size: 0.95rem;
+}
+
+.round-card {
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(255, 255, 255, 0.82);
+  margin-bottom: 1rem;
+  overflow: hidden;
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.12);
+}
+
+.round-header {
+  padding: 0.85rem 1.2rem;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  background: rgba(59, 130, 246, 0.15);
+  color: #0f172a;
+}
+
+.round-header h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.match-row {
+  display: grid;
+  grid-template-columns: 70px 1fr auto 1fr 160px;
+  gap: 0.75rem;
+  align-items: center;
+  padding: 0.85rem 1.2rem;
+  border-bottom: 1px solid rgba(226, 232, 240, 0.7);
+}
+
+.match-row:last-child {
+  border-bottom: none;
+}
+
+.match-row .player {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.match-row .player span:first-child {
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.match-row .player span:last-child {
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.match-row .versus {
+  justify-self: center;
+  font-weight: 700;
+  color: #475569;
+}
+
+.badge.win {
+  background: rgba(34, 197, 94, 0.18);
+  color: #047857;
+}
+
+.badge.loss {
+  background: rgba(248, 113, 113, 0.18);
+  color: #b91c1c;
+}
+
+.badge.draw {
+  background: rgba(251, 191, 36, 0.2);
+  color: #92400e;
+}
+
+.meta-grid {
+  display: grid;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  color: #475569;
+}
+
+@media (max-width: 900px) {
+  .match-row {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-areas:
+      "table table"
+      "p1 p2"
+      "result result";
+    gap: 0.5rem;
+  }
+  .match-row .table-id {
+    grid-area: table;
+  }
+  .match-row .player:first-of-type {
+    grid-area: p1;
+  }
+  .match-row .player:last-of-type {
+    grid-area: p2;
+  }
+  .match-row .versus {
+    display: none;
+  }
+  .match-row select.match-result {
+    grid-area: result;
+    justify-self: start;
+  }
+  table {
+    min-width: unset;
+  }
+}
+
+.empty-state {
+  padding: 1.5rem;
+  border-radius: 16px;
+  border: 1px dashed rgba(148, 163, 184, 0.6);
+  text-align: center;
+  color: #475569;
+}


### PR DESCRIPTION
## Summary
- add a static HTML entry point that loads a new tournament manager front-end
- port the workbook rules, roster, and round-one pairings into a reusable data module and render them with interactive standings, results, and Swiss pair generation
- style the experience and document how to launch the browser-based tool

## Testing
- not run (browser-based UI)


------
https://chatgpt.com/codex/tasks/task_e_68db506c5604832c9ffcfed040d4ebb9